### PR TITLE
Incorrect PATH_SEPARATOR for Windows platform

### DIFF
--- a/bin/ejekyll
+++ b/bin/ejekyll
@@ -4,6 +4,7 @@
 
 require 'rubygems'
 require 'jekyll'
+require 'ftools'
 
 require File.join(File.dirname(__FILE__), '..', 'lib', 'aop.rb')
 
@@ -48,5 +49,5 @@ module Jekyll
 
 end
 
-original_jekyll = ENV['PATH'].split(':').collect { |d| "#{d}/jekyll" }.find{ |p| File.exists?(p) }
+original_jekyll = ENV['PATH'].split(File::PATH_SEPARATOR).collect { |d| "#{d}/jekyll" }.find{ |p| File.exists?(p) }
 load original_jekyll


### PR DESCRIPTION
Hi Raoul !
Hope you enjoyed some holidays !

A little message to report a little bug concerning jekyll_ext on Windows platform :
The ejekyll gem on last line retrieves original_jekyll by splitting ENV_PATH which separator is hardcoded by ':' in the code.
This works on linux and probably MacOS, but not on Windows (which uses ';' as PATH_SEPARATOR)

I found something regarding this on http://ruby-doc.org/docs/ProgrammingRuby/html/ref_c_file.html

I tested the correction on Windows,
Regards,
